### PR TITLE
Simplify base routing key in conf

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,4 +6,4 @@ you can run a module after installing cloudbrain: `python cloudbrain.run
 <br>
 <br>
 For example, to run the mock source module, you can run: `python cloudbrain
-.run --file base_modules/source.mock.json`.
+.run --file source.mock.json`.

--- a/examples/chained_modules/heart.json
+++ b/examples/chained_modules/heart.json
@@ -18,7 +18,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_raw",
@@ -49,7 +49,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_raw",
@@ -69,7 +69,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_filtered",
@@ -97,7 +97,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_filtered",
@@ -116,7 +116,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "bpm",
@@ -153,7 +153,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "bpm",
@@ -172,7 +172,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "nervous",

--- a/examples/chained_modules/heart.mock.json
+++ b/examples/chained_modules/heart.mock.json
@@ -23,7 +23,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_raw",
@@ -37,7 +37,7 @@
           "package": "cloudbrain.publishers.pipe",
           "options": {
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_raw",
@@ -68,7 +68,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_raw",
@@ -88,7 +88,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_filtered",
@@ -116,7 +116,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_filtered",
@@ -135,7 +135,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "bpm",
@@ -172,7 +172,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "bpm",
@@ -191,7 +191,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "nervous",

--- a/examples/filter.band.pass.json
+++ b/examples/filter.band.pass.json
@@ -19,7 +19,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",
@@ -38,7 +38,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "heart_rate",

--- a/examples/filter.band.stop.json
+++ b/examples/filter.band.stop.json
@@ -19,7 +19,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",
@@ -38,7 +38,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg_no_notch",

--- a/examples/sink.pyplot.json
+++ b/examples/sink.pyplot.json
@@ -19,7 +19,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",

--- a/examples/sink.stdout.json
+++ b/examples/sink.stdout.json
@@ -16,7 +16,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",

--- a/examples/source.mock.json
+++ b/examples/source.mock.json
@@ -23,7 +23,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",
@@ -41,7 +41,7 @@
           "name": "PipePublisher",
           "package": "cloudbrain.publishers.pipe",
           "options": {},
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",

--- a/examples/source.muse.python2.json
+++ b/examples/source.muse.python2.json
@@ -18,7 +18,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",

--- a/examples/source.muse.python3.json
+++ b/examples/source.muse.python3.json
@@ -18,7 +18,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",

--- a/examples/source.openci.json
+++ b/examples/source.openci.json
@@ -18,7 +18,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",
@@ -31,7 +31,7 @@
           "name": "PipePublisher",
           "package": "cloudbrain.publishers.pipe",
           "options": {},
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg",

--- a/examples/transform.fft.json
+++ b/examples/transform.fft.json
@@ -27,7 +27,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "alpha",
@@ -52,7 +52,7 @@
             "rabbitmq_pwd": "guest",
             "rabbitmq_vhost": "/"
           },
-          "base_routing_key": "some_unique_id:device_name",
+          "base_routing_key": "some_unique_key",
           "metrics": [
             {
               "metric_name": "eeg_no_notch",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pika==0.10
 numpy==1.11.2
 scipy==0.18.1
 pyserial==2.7
-requests==2.11.1
+requests[security]==2.11.1

--- a/src/cloudbrain/core/config.json
+++ b/src/cloudbrain/core/config.json
@@ -1,4 +1,4 @@
 {
   "authUrl": "https://auth.getcloudbrain.com",
-  "rabbitHost": "broker.gecloudbrain.com"
+  "rabbitHost": "broker.getcloudbrain.com"
 }


### PR DESCRIPTION
With the new auth mechanism in place and the changes to remove device_id across cloudbrain, we no longer need to prepend a device name with a unique id (ex:  unique_id:device_name). We can now simply ensure that the full key is unique (ex: unique_key)
