### PR TITLE
Csv sink

### DIFF
--- a/examples/sink.csv.json
+++ b/examples/sink.csv.json
@@ -1,0 +1,31 @@
+{
+  "modules": [
+    {
+      "name": "CSVOutSink",
+      "package": "cloudbrain.modules.sinks.csvout",
+      "options": {
+        "out_dir": "/tmp"
+      },
+      "subscribers": [
+        {
+          "name": "PikaSubscriber",
+          "package": "cloudbrain.subscribers.rabbitmq",
+          "options": {
+            "rabbitmq_address": "localhost",
+            "rabbitmq_user": "guest",
+            "rabbitmq_pwd": "guest",
+            "rabbitmq_vhost": "/"
+          },
+          "base_routing_key": "some_unique_key",
+          "metrics": [
+            {
+              "metric_name": "eeg",
+              "num_channels": 8
+            }
+          ]
+        }
+      ],
+      "publishers": []
+    }
+  ]
+}

--- a/src/cloudbrain/modules/sinks/csvout.py
+++ b/src/cloudbrain/modules/sinks/csvout.py
@@ -61,7 +61,6 @@ class CSVOutSink(ModuleInterface):
             # For each metric buffer in the router open a file handle
             # and save the corresponding CSV writer object
             for metric_buffer in subscriber.metric_buffers.values():
-                num_channels = metric_buffer.num_channels
                 d = {'base_routing_key': _clean_key(base_routing_key),
                      'metric_name': _clean_string(metric_buffer.name)}
                 file_name = self.file_name_pattern.format(**d)

--- a/src/cloudbrain/modules/sinks/csvout.py
+++ b/src/cloudbrain/modules/sinks/csvout.py
@@ -1,6 +1,7 @@
+import csv
+import errno
 import json
 import logging
-import csv
 import re
 import time
 import os
@@ -8,6 +9,21 @@ import os
 from cloudbrain.modules.interface import ModuleInterface
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def mkdir_p(path):
+    """
+    Emulate the "mkdir -p" funcitonality of bash. See:
+    https://stackoverflow.com/questions/600268/
+    mkdir-p-functionality-in-python/600612#600612
+    """
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
 
 def _clean_key(key):
@@ -49,7 +65,7 @@ class CSVOutSink(ModuleInterface):
 
         if not os.path.exists(out_dir):
             _LOGGER.info("Creating missing directory {}".format(out_dir))
-            os.mkdir(out_dir)
+            mkdir_p(out_dir)
 
         self.thread_event = thread_event
         self.headers = {}

--- a/src/cloudbrain/modules/sinks/csvout.py
+++ b/src/cloudbrain/modules/sinks/csvout.py
@@ -58,7 +58,7 @@ class CSVOutSink(ModuleInterface):
         TODO: Delete, back up, or warn of existing files to prevent
         new headers from corrupting existing data.
         """
-        thread_event=False
+        thread_event = False
         super(CSVOutSink, self).__init__(subscribers, publishers)
         _LOGGER.debug("Subscribers: %s" % self.subscribers)
         _LOGGER.debug("Publishers: %s" % self.publishers)
@@ -89,7 +89,8 @@ class CSVOutSink(ModuleInterface):
                 self.out_files[file_name] = writer
 
     def _csv_callback_factory(self, file_name):
-        def _csv_callback(unsed_ch, unsed_method, unsed_properties, json_string):
+        def _csv_callback(unsed_ch, unsed_method, unsed_properties,
+                          json_string):
             """
             Parse a JSON data message and write its contents to the appropriate
             CSV
@@ -111,7 +112,7 @@ class CSVOutSink(ModuleInterface):
             for metric_buffer in subscriber.metric_buffers.values():
                 num_channels = metric_buffer.num_channels
                 d = {'base_routing_key': _clean_key(base_routing_key),
-                     'metric_name': metric_buffer.name}
+                     'metric_name': _clean_string(metric_buffer.name)}
                 file_name = self.file_name_pattern.format(**d)
                 csv_callback = self._csv_callback_factory(file_name)
                 routing_key = subscriber.base_routing_key
@@ -119,5 +120,3 @@ class CSVOutSink(ModuleInterface):
                 subscriber.subscribe(metric_buffer.name, csv_callback)
         while self.thread_event:
             time.sleep(1)
-
-

--- a/src/cloudbrain/modules/sinks/csvout.py
+++ b/src/cloudbrain/modules/sinks/csvout.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import csv
+import re
 import time
 import os
 
@@ -19,6 +20,19 @@ def _clean_key(key):
     return: The key with colons replaced with underscores
     """
     return '_'.join(key.split(':')) if ':' in key else key
+
+
+def _clean_string(s):
+    """
+    Return the given string converted to a string that can be used for a clean
+    filename. Remove leading and trailing spaces; convert other spaces to
+    underscores; and remove anything that is not an alphanumeric, dash,
+    underscore, or dot.
+    >>> _clean_string("john's portrait in 2004.jpg")
+    'johns_portrait_in_2004.jpg'
+    """
+    s = str(s).strip().replace(' ', '_')
+    return re.sub(r'(?u)[^-\w.]', '_', s)
 
 
 class CSVOutSink(ModuleInterface):
@@ -49,7 +63,7 @@ class CSVOutSink(ModuleInterface):
             for metric_buffer in subscriber.metric_buffers.values():
                 num_channels = metric_buffer.num_channels
                 d = {'base_routing_key': _clean_key(base_routing_key),
-                     'metric_name': metric_buffer.name}
+                     'metric_name': _clean_string(metric_buffer.name)}
                 file_name = self.file_name_pattern.format(**d)
                 _LOGGER.info("Opening file: {}".format(file_name))
                 f = open(os.path.join(out_dir, file_name), 'w+')


### PR DESCRIPTION
@flysonic10 

This fixes 2 bugs:
* Create directories recursively, if the path to outdir does not exist.
* Slugify csv output file name.

I also added an example config JSON file.

You can test all this with the mock source, and use a weird metric name like /muse/eeg or $toto$.